### PR TITLE
Feat/make rule function

### DIFF
--- a/docs/rule.md
+++ b/docs/rule.md
@@ -1,9 +1,0 @@
-# Rule
-
-Missil main class. Works as a FastAPI [dependency](https://fastapi.tiangolo.com/reference/dependencies/?h=depen), so it can be injected in API routes.
-
-::: missil.Rule
-
-## Make Rules
-
-::: missil.make_rules

--- a/docs/rules.md
+++ b/docs/rules.md
@@ -4,6 +4,10 @@ Missil main class. Works as a FastAPI [dependency](https://fastapi.tiangolo.com/
 
 ::: missil.Rule
 
+## Make Rule
+
+:: missil.make_rule
+
 ## Make Rules
 
 ::: missil.make_rules

--- a/missil/__init__.py
+++ b/missil/__init__.py
@@ -14,6 +14,7 @@ from missil.rules import DENY
 from missil.rules import READ
 from missil.rules import WRITE
 from missil.rules import Rule
+from missil.rules import make_rule
 from missil.rules import make_rules
 
 
@@ -27,6 +28,7 @@ __all__ = [
     "HTTPTokenBearer",
     "FlexibleTokenBearer",
     "Rule",
+    "make_rule",
     "make_rules",
     "QualifiedRouter",
     "READ",

--- a/missil/rules.py
+++ b/missil/rules.py
@@ -191,3 +191,22 @@ def make_rules(bearer: TokenBearer, *areas: str) -> dict[str, Area]:
         Dict containing endpoint-appliable rules.
     """
     return {area: Area(area, bearer) for area in areas}
+
+
+def make_rule(bearer: TokenBearer, area: str) -> Area:
+    """
+    Create a single Missil rule.
+
+    Parameters
+    ----------
+    bearer : TokenBearer
+        JWT token source source. See Bearers module.
+    area : str
+        A business area name.
+
+    Returns
+    -------
+    Area
+        Business area object, containing READ and WRITE rules.
+    """    
+    return Area(area, bearer)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,4 +1,5 @@
 from missil import make_rule
+from missil import make_rules
 from missil.rules import Area
 from missil.rules import Rule
 
@@ -9,3 +10,21 @@ def test_make_rule(bearer_token):
     assert isinstance(test_area, Area)
     assert isinstance(test_area.READ, Rule)
     assert isinstance(test_area.WRITE, Rule)
+    
+def test_make_rules_single_ba(bearer_token):
+    test_area = make_rules(bearer_token, "test_1")
+    assert "test_1" in test_area
+    assert isinstance(test_area["test_1"], Area)
+    assert isinstance(test_area["test_1"].READ, Rule)
+    assert isinstance(test_area["test_1"].WRITE, Rule)
+
+def test_make_rules_multiple_bas(bearer_token):
+    test_areas = make_rules(bearer_token, "test_1", "test_2")
+    assert "test_1" in test_areas
+    assert "test_2" in test_areas
+    assert isinstance(test_areas["test_1"], Area)
+    assert isinstance(test_areas["test_2"], Area)
+    assert isinstance(test_areas["test_1"].READ, Rule)
+    assert isinstance(test_areas["test_2"].READ, Rule)
+    assert isinstance(test_areas["test_1"].WRITE, Rule)
+    assert isinstance(test_areas["test_2"].WRITE, Rule)

--- a/tests/test_rules.py
+++ b/tests/test_rules.py
@@ -1,0 +1,11 @@
+from missil import make_rule
+from missil.rules import Area
+from missil.rules import Rule
+
+
+def test_make_rule(bearer_token):
+    test_area = make_rule(bearer_token, "test")
+    assert test_area.name == "test"
+    assert isinstance(test_area, Area)
+    assert isinstance(test_area.READ, Rule)
+    assert isinstance(test_area.WRITE, Rule)


### PR DESCRIPTION
# Description

Missil already have a ```make_rules``` function, but not a similar way to create a single rule. This PR solves that lack of this feature.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
